### PR TITLE
Docker build updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:dubnium
+FROM node:16-bullseye-slim
 
 EXPOSE 8080
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "install": "npm run build",
     "build": "tsc",
     "docker:build": "npm run build && docker build -t nbering/docker-check .",
     "docker:shell": "docker run --init --rm -it nbering/docker-check /bin/bash",


### PR DESCRIPTION
Update base image, and remove install script from package.json.

The install script didn't work without dev dependencies installed. Currently depending on pre-compiling the typescript before docker build.