### PR TITLE
Use multi-stage build to constrain build to Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,22 @@
-FROM node:16-bullseye-slim
+FROM node:16-bullseye-slim AS builder
 
-EXPOSE 8080
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm ci
+# COPY tsconfig*.json ./
+COPY . .
+RUN npm run build
+
+FROM node:16-bullseye-slim
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-COPY package.json /usr/src/app
-RUN npm install -g node-gyp; \
-    npm install --only=prod --no-optional
+COPY package*.json ./
 
-COPY . /usr/src/app
+RUN npm install --only=prod --no-optional
 
+COPY --from=builder /usr/src/app/dist dist/
+
+EXPOSE 8080
 CMD ["npm", "start"]

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc",
-    "docker:build": "npm run build && docker build -t nbering/docker-check .",
+    "docker:build": "docker build -t nbering/docker-check .",
     "docker:shell": "docker run --init --rm -it nbering/docker-check /bin/bash",
     "docker:run": "docker run --init -p 8080:8080 --rm -it nbering/docker-check",
-    "start": "node index.js"
+    "start": "node dist/index.js"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    "outDir": "dist",                         /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "removeComments": true,                /* Do not emit comments to output. */
     // "noEmit": true,                        /* Do not emit outputs. */


### PR DESCRIPTION
Before, I was relying on typescript running locally to avoid installing dev dependencies in the final container.

This PR breaks the compilation into a "builder" container phase, and the final image has JS files copied from the builder.